### PR TITLE
Update default_module_mapping.py to add snowflake's snowpark

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -238,6 +238,7 @@ DEFAULT_MODULE_MAPPING = {
     "sseclient-py": ("sseclient",),
     "setuptools": ("easy_install", "pkg_resources", "setuptools"),
     "snowflake-connector-python": ("snowflake.connector",),
+    "snowflake-snowpark-python": ("snowflake.snowpark",),
     "snowflake-sqlalchemy": ("snowflake.sqlalchemy",),
     "strawberry-graphql": ("strawberry",),
     "streamlit-aggrid": ("st_aggrid",),


### PR DESCRIPTION
Very common in the snowflake world. Deserves a default mapping, imo.

Tested locally with an entry in BUILD like:
```python
python_requirements(
    name="dag",
    resolve="dag",
    source="dag-requirements.txt",
    module_mapping={
        "snowflake-snowpark-python": ("snowflake.snowpark",),
    }
)
```